### PR TITLE
Fix an issue with regions when running on EC2 when AWS_DEFAULT_REGION is not set.

### DIFF
--- a/1config-core/src/com/brunobonacci/oneconfig/backends/kms_encryption.clj
+++ b/1config-core/src/com/brunobonacci/oneconfig/backends/kms_encryption.clj
@@ -18,13 +18,13 @@
   (delay
    (or
     ;; for dev mode just use `defcredential` macro
-    (some-> #'aws/credential deref deref :endpoint Regions/fromName)
+    (some-> #'aws/credential deref deref :endpoint Regions/fromName Region/getRegion)
     ;; check env
-    (some-> (env "AWS_DEFAULT_REGION") Regions/fromName)
+    (some-> (env "AWS_DEFAULT_REGION") Regions/fromName Region/getRegion)
     ;; this call blocks and it is slow on non EC2
     (Regions/getCurrentRegion)
     ;; us-west-2 (??)
-    (Regions/DEFAULT_REGION))))
+    (-> Regions/DEFAULT_REGION Region/getRegion))))
 
 
 
@@ -121,7 +121,7 @@
          (KmsMasterKeyProvider.
           ;; reuse amazonica credential variable
           (aws/get-credentials (some-> #'aws/credential deref deref))
-          (Region/getRegion @aws-region)
+          ^Region @aws-region
           (PredefinedClientConfigurations/defaultConfig)
           (key-id master-key-id))
          ;; sanitize context if present
@@ -147,7 +147,7 @@
          (KmsMasterKeyProvider.
           ;; reuse amazonica credential variable
           (aws/get-credentials (some-> #'aws/credential deref deref))
-          (Region/getRegion @aws-region)
+          ^Region @aws-region
           (PredefinedClientConfigurations/defaultConfig)
           (Collections/emptyList))
          ;; sanitize context if present


### PR DESCRIPTION
The `(Regions/getCurrentRegion)` returns`com.amazonaws.regions.Region` rather than `com.amazonaws.regions.Regions`. This causes a class cast exception when running in EC2 (and when AWS_DEFAULT_PROFILE is not set). I have changed the `@aws-region` atom to consistently hold `com.amazonaws.regions.Region` instead to fix this issue.