### PR TITLE
Add `1config.home` system property

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ pom.xml.asc
 /1config-ui/.rebel_readline_history
 /1config-ui/figwheel_server.log
 /1config-cli/reports/
+.cache
+.calva

--- a/1config-core/src/com/brunobonacci/oneconfig/util.clj
+++ b/1config-core/src/com/brunobonacci/oneconfig/util.clj
@@ -223,11 +223,13 @@
 
 
 (defn config-property
-  [prop-name env-name default]
-  (or
-    (system-property prop-name)
-    (env env-name)
-    default))
+  ([prop-name env-name]
+   (config-property prop-name env-name nil))
+  ([prop-name env-name default]
+   (or
+     (system-property prop-name)
+     (env env-name)
+     default)))
 
 
 
@@ -272,11 +274,11 @@
 
 
 (defn home-1config
-  "returns ONECONFIG_HOME from the environment if it is set otherwise it
-  returns ~/.1config"
+  "Returns the 1config home directory from either `1config.home` system property
+   or `ONECONFIG_HOME` environment. If neither exists it returns ~/.1config"
   []
   (let [home (homedir)
-        oneconfig-home (env "ONECONFIG_HOME")]
+        oneconfig-home (config-property "1config.home" "ONECONFIG_HOME")]
     (cond
       (and oneconfig-home (not (dir-exists? oneconfig-home)))
       (log/warn "ONECONFIG_HOME is set, but its either not a directory or it doesn't exist.")

--- a/1config-core/test/com/brunobonacci/oneconfig/util_test.clj
+++ b/1config-core/test/com/brunobonacci/oneconfig/util_test.clj
@@ -1,0 +1,12 @@
+(ns com.brunobonacci.oneconfig.util-test
+  (:require [com.brunobonacci.oneconfig.util :as ut]
+            [midje.sweet :refer [fact]]))
+
+
+
+(fact "You can override the 1config home directory with the `1config.home` property"
+  (def dir "/tmp")
+  (System/setProperty "1config.home" dir)
+  (ut/home-1config) => dir
+  (System/clearProperty "1config.home")
+  )


### PR DESCRIPTION
This is useful to programmatically change the one config home directory. You may want to do this for writing unit tests in your services with a generated configuration for example.